### PR TITLE
0.2.4 Fixes

### DIFF
--- a/ppp/PlanetaryPendulumPeriodicity.js
+++ b/ppp/PlanetaryPendulumPeriodicity.js
@@ -8,11 +8,22 @@ var id = "Planetary Pendulum Periodicity";
 var name = "Planetary Pendulum Periodicity";
 var description = "This theory explores the changing of the frequency of a pendulum upon increasing the gravity it is subjected to by throwing lots of mass together.";
 var authors = "Warzen User";
-var version = '0.2.2';
+var version = '0.2.3';
 
 var currency, currency2;
 var c1, L;
 let stage = 1;
+let p1;
+let muUpg;
+var c1Exp;
+var lastc1lvl;
+let planet, constG;
+let r = 'r_{\\odot}';
+let M = 'M_{\\odot}';
+let G = 'G';
+
+var achievement1, achievement2, achievement3, achievement4;
+let tutorial, chapter1, chapter2, chapter3, chapter4, chapter5, chapter6, chapter7;
 
 const constants = [
     {
@@ -80,18 +91,6 @@ const materials = (lvl, type) => {
     }
     return all[lvl || 0][type];
 };
-let p1;
-let muUpg;
-var c1Exp;
-var lastc1lvl;
-let planet, constG;
-let r = 'r_{\\odot}';
-let M = 'M_{\\odot}';
-let G = 'G';
-let ddt = 0;
-
-var achievement1, achievement2, achievement3, achievement4;
-let tutorial, chapter1, chapter2, chapter3, chapter4, chapter5, chapter6, chapter7;
 
 var init = () => {
     currency = theory.createCurrency(symbol = 'µ', latexSymbol='\\mu');
@@ -225,7 +224,6 @@ var tick = (elapsedTime, multiplier) => {
     theory.invalidatePrimaryEquation();
     theory.invalidateSecondaryEquation();
     theory.invalidateTertiaryEquation();
-    ddt = elapsedTime * multiplier;
     if (getC1(c1.level) == 0) return;
     
     let dt = BigNumber.from(elapsedTime * multiplier);
@@ -333,16 +331,6 @@ var goToPreviousStage = () => stage = Math.max(stage-1, 0);
 var goToNextStage = () => stage = Math.min(stage+1, 1);
 
 init();
-
-const smolNum = (a, type='str') => {
-    if (!a) return '0.00';
-    let h = Math.log10(a);
-    let j = Math.floor(h);
-    let k = Math.abs(h - j);
-    let [mts, exp] = [Math.pow(10, k).toPrecision(3), j];
-    if (type == 'num') a;
-    return `${mts}e${exp}`;
-}
 
 const expMantissa = (val) => {
     const exp = Math.log10(val);

--- a/ppp/PlanetaryPendulumPeriodicity.js
+++ b/ppp/PlanetaryPendulumPeriodicity.js
@@ -8,7 +8,7 @@ var id = "Planetary Pendulum Periodicity";
 var name = "Planetary Pendulum Periodicity";
 var description = "This theory explores the changing of the frequency of a pendulum upon increasing the gravity it is subjected to by throwing lots of mass together.";
 var authors = "Warzen User";
-var version = '0.2.3';
+var version = '0.2.4';
 
 var currency, currency2;
 var c1, L;
@@ -173,7 +173,7 @@ var init = () => {
             theory.invalidateSecondaryEquation();
             theory.invalidateTertiaryEquation();
         };
-        constG = 6.6743 * Math.pow(10, -11);
+        constG = BigNumber.from(6.6743 * Math.pow(10, -11));
     }
     
     /////////////////
@@ -234,7 +234,7 @@ var tick = (elapsedTime, multiplier) => {
     vol += dt * V;
     if (lastc1lvl < c1.level) {
         lastc1lvl = c1.level;
-        currency2.value = Math.max(0, currency2.value - (vol / V));
+        currency2.value = Math.max(BigNumber.ZERO, currency2.value - (vol / V));
     } else {
         currency2.value += dt * vol * bonus;
     }
@@ -260,7 +260,7 @@ var getPrimaryEquation = () => {
             {${r}} = \\frac{{3V}}{4\\pi}\\; ^ {\\frac{{1}}{3}} \\;, \\quad V = V_0 + \\sum_{n=${getMaterialForm(0)}}^{${getMaterialForm(p1.level)}} V_{n} \\;, \\quad \\dot{${M}} = c_1 \\, ^{${c1Exp.level > 0 ? 1 + c1Exp.level*.025 : ''}}
             \\\\\\\\
             \\\\\\\\
-            ${G} = 6.67430\\cdot 10^{-11} \\frac{{m^3}}{kg \\cdot s^{2}}
+            ${G} = 6.67430e-11 \\frac{{m^3}}{kg \\cdot s^{2}}
             \\end{matrix}
         `;
     } else if (stage == 1) {
@@ -288,7 +288,7 @@ var getTertiaryEquation = () => {
 
 var postPublish = () => {
     planet = constants[SO.level];
-    mass = planet.mass;
+    mass = BigNumber.from(planet.mass);
     V = BigNumber.from(mass / planet.density);
     vol = V;
     radius = R(V);
@@ -339,7 +339,7 @@ const expMantissa = (val) => {
     return { mts: mantissa, exp: expClean };
 }
 
-const R = (v) => (v/(4/3 * Math.PI)).pow(1/3);
+const R = (v) => (v/((BigNumber.FOUR/BigNumber.THREE) * BigNumber.PI)).pow(BigNumber.ONE/BigNumber.THREE);
 const Grav = (mass, rad, type='number') => {
     if (rad == 0) return type == 'number' ? 0 : '0.00';
     try {
@@ -394,7 +394,7 @@ const Frec = (gravity, type='number') => {
         return BigNumber.from((Math.pow(gravity, .5) / (BigNumber.TWO * BigNumber.PI * Math.pow(getL(L.level), .5))));
     }
 }
-let mass = planet.mass;
+let mass = BigNumber.from(planet.mass);
 let V = BigNumber.from(mass / planet.density);
 let vol = V;
 let radius = R(V);

--- a/ppp/PlanetaryPendulumPeriodicity.js
+++ b/ppp/PlanetaryPendulumPeriodicity.js
@@ -8,7 +8,7 @@ var id = "Planetary Pendulum Periodicity";
 var name = "Planetary Pendulum Periodicity";
 var description = "This theory explores the changing of the frequency of a pendulum upon increasing the gravity it is subjected to by throwing lots of mass together.";
 var authors = "Warzen User";
-var version = '0.2.0';
+var version = '0.2.1';
 
 var currency, currency2;
 var c1, L;
@@ -71,11 +71,11 @@ const materials = (lvl, type) => {
         {'name': '\\text{oxygen}', 'value': 1.429, 'form': 'O'},
     ].sort((a, b) => a.value - b.value);
     const totalAtoms = all.length;
-    if (lvl > totalAtoms) {
+    if (lvl >= totalAtoms) {
         return {
-            'name': `\\text{bigatom_{${lvl-totalAtoms}}}`,
+            'name': `\\text{bigatom_{${lvl - totalAtoms + 1}}}`,
             'value': all[totalAtoms - 1]['value'] * Math.pow(lvl/2, 1.01),
-            'form': `Ba_{${lvl-totalAtoms}}`,
+            'form': `\\beta_{${lvl - totalAtoms + 1}}`,
         }[type];
     }
     return all[lvl || 0][type];

--- a/ppp/PlanetaryPendulumPeriodicity.js
+++ b/ppp/PlanetaryPendulumPeriodicity.js
@@ -8,11 +8,11 @@ var id = "Planetary Pendulum Periodicity";
 var name = "Planetary Pendulum Periodicity";
 var description = "This theory explores the changing of the frequency of a pendulum upon increasing the gravity it is subjected to by throwing lots of mass together.";
 var authors = "Warzen User";
-var version = '0.2.1';
+var version = '0.2.2';
 
 var currency, currency2;
 var c1, L;
-let stage = 0;
+let stage = 1;
 
 const constants = [
     {


### PR DESCRIPTION
Fix problems with density: 0.2.1
- Name numbering
- Error when retrieving
- Form symbol and numbering

Changed stage: 0.2.2
- Stage is now always starting at 1 (values)

Variables: 0.2.3
- Removed unused varable ddt and function smolNum.
- Reorganizaed variable declarations.

Precision and notation: 0.2.4
- Changed constG is now BigNumber and notation used is standardized.
- Changed some missing BigNumber uses in certain calculations.
- Changed mass is now BigNumber.
